### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/pkg/inspect/atlas_sdk.go
+++ b/pkg/inspect/atlas_sdk.go
@@ -42,15 +42,21 @@ func (d atlasDiscoverer) discoverViaSDK(ctx context.Context, opts Options) ([]Ma
 
 	var groups []admin.Group
 	if c.OrgID != "" {
-		resp, _, err := client.OrganizationsApi.GetOrgGroups(ctx, c.OrgID).Execute()
+		resp, hr, err := client.OrganizationsApi.GetOrgGroups(ctx, c.OrgID).Execute()
 		if err != nil {
 			return nil, nil, fmt.Errorf("atlas list org projects: %w", err)
 		}
+		if hr != nil {
+			_ = hr.Body.Close()
+		}
 		groups = resp.GetResults()
 	} else {
-		resp, _, err := client.ProjectsApi.ListGroups(ctx).Execute()
+		resp, hr, err := client.ProjectsApi.ListGroups(ctx).Execute()
 		if err != nil {
 			return nil, nil, fmt.Errorf("atlas list projects: %w", err)
+		}
+		if hr != nil {
+			_ = hr.Body.Close()
 		}
 		groups = resp.GetResults()
 	}
@@ -61,10 +67,13 @@ func (d atlasDiscoverer) discoverViaSDK(ctx context.Context, opts Options) ([]Ma
 	)
 	for i := range groups {
 		gid := groups[i].GetId()
-		resp, _, err := client.ClustersApi.ListClusters(ctx, gid).Execute()
+		resp, hr, err := client.ClustersApi.ListClusters(ctx, gid).Execute()
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("atlas project %s: %v", gid, err))
 			continue
+		}
+		if hr != nil {
+			_ = hr.Body.Close()
 		}
 		for _, cl := range resp.GetResults() {
 			db, warns := atlasSDKCluster(cl, c.OrgID, opts)

--- a/pkg/inspect/aws_sdk.go
+++ b/pkg/inspect/aws_sdk.go
@@ -101,10 +101,8 @@ func awsListAccounts(ctx context.Context, cfg aws.Config) ([]string, error) {
 
 func awsScanAccount(ctx context.Context, cfg aws.Config, account string, opts Options) ([]ManagedDatabase, []string) {
 	regions, warns := awsSDKRegions(ctx, cfg, opts)
-	var (
-		out      []ManagedDatabase
-		warnings = warns
-	)
+	out := make([]ManagedDatabase, 0, len(regions))
+	warnings := warns
 	for _, region := range regions {
 		rcfg := cfg.Copy()
 		rcfg.Region = region

--- a/pkg/inspect/aws_sdk.go
+++ b/pkg/inspect/aws_sdk.go
@@ -64,7 +64,8 @@ func (d awsDiscoverer) discoverViaSDK(ctx context.Context, opts Options) ([]Mana
 			roleArn := fmt.Sprintf("arn:aws:iam::%s:role/OrganizationAccountAccessRole", acct)
 			acctCfg := baseCfg.Copy()
 			acctCfg.Credentials = aws.NewCredentialsCache(
-				stscreds.NewAssumeRoleProvider(stsClient, roleArn))
+				stscreds.NewAssumeRoleProvider(stsClient, roleArn),
+			)
 			dbs, warns := awsScanAccount(ctx, acctCfg, acct, opts)
 			out = append(out, dbs...)
 			warnings = append(warnings, warns...)


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
